### PR TITLE
Reset height to initial value, otherwise recalculate is not possible

### DIFF
--- a/equalheight.js
+++ b/equalheight.js
@@ -18,10 +18,12 @@
         init: function () {
             var height = 0;
 
-            this.$els.each(function () {
-                var temp = $(this).height();
-                height = (height < temp) ? temp : height;
-            }).height(height);
+            this.$els
+                .css({ 'height': '' })
+                .each(function () {
+                    var temp = $(this).height();
+                    height = (height < temp) ? temp : height;
+                }).height(height);
         }
     };
 


### PR DESCRIPTION
I needed a situation, where equal heights where calculated in a hidden parent, which resulted in height zero. Recalculating was not possible because they all had a zero height now.
